### PR TITLE
Only keep the "local-authority" tag if an org is also a "public-service"

### DIFF
--- a/results.json
+++ b/results.json
@@ -16801,9 +16801,6 @@
           "kind": "local-authority"
         },
         {
-          "kind": "public-service"
-        },
-        {
           "kind": "certified"
         }
       ],
@@ -17062,9 +17059,6 @@
       "badges": [
         {
           "kind": "local-authority"
-        },
-        {
-          "kind": "public-service"
         },
         {
           "kind": "certified"
@@ -19982,9 +19976,6 @@
       "badges": [
         {
           "kind": "local-authority"
-        },
-        {
-          "kind": "public-service"
         }
       ],
       "business_number_id": "21010262000106",
@@ -20276,9 +20267,6 @@
       "badges": [
         {
           "kind": "local-authority"
-        },
-        {
-          "kind": "public-service"
         }
       ],
       "business_number_id": "20005376700014",
@@ -24331,9 +24319,6 @@
         },
         {
           "kind": "certified"
-        },
-        {
-          "kind": "public-service"
         }
       ],
       "business_number_id": "20003470000019",


### PR DESCRIPTION
Fixes [#1433](https://github.com/datagouv/data.gouv.fr/issues/1433) with the udata PR [#3200](https://github.com/opendatateam/udata/pull/3200)

This needs to be tagged `v4.0.0` when it's merged.